### PR TITLE
SOLVED mongooseerror: model.findone() no longer accepts a callback

### DIFF
--- a/Level 6: passport-google-oauth20/config/passport.js
+++ b/Level 6: passport-google-oauth20/config/passport.js
@@ -13,7 +13,8 @@ passport.use(
       callbackURL: "http://localhost:5000/auth/google/callback",
     },
     function (accessToken, refreshToken, profile, cb) {
-      User.findOne({ googleId: profile.id }, (err, user) => {
+      User.findOne({ googleId: profile.id })
+      .then((err, user) => {
         if (err) return cb(err, null);
 
         // not a user; so create a new user with new google id


### PR DESCRIPTION
Mongo dropped support for callbacks from its node.js driver as of version 5.0 in favour of a Promise-only public API. Mongoose also dropped callback support in v7 so findOne() and other methods now always return a promise.